### PR TITLE
Performance additions and small fixes

### DIFF
--- a/msvc/acc.vcxproj
+++ b/msvc/acc.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -52,57 +52,57 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -200,7 +200,7 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
@@ -211,13 +211,16 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -290,11 +293,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
@@ -304,14 +307,15 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>false</GenerateDebugInformation>

--- a/msvc/core.vcxproj
+++ b/msvc/core.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -52,57 +52,57 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -190,28 +190,31 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\boost_1_49_0;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\boost_1_49_0;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">
@@ -253,11 +256,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -266,14 +269,15 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <CompileAs>CompileAsCpp</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">
@@ -395,7 +399,10 @@
     <ClCompile Include="..\libs\core\bitstream.cpp" />
     <ClCompile Include="..\libs\core\common.cpp" />
     <ClCompile Include="..\libs\core\crc.cpp" />
-    <ClCompile Include="..\libs\core\endian.cpp" />
+    <ClCompile Include="..\libs\core\endian.cpp">
+      <FloatingPointModel Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">Strict</FloatingPointModel>
+      <FloatingPointModel Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">Strict</FloatingPointModel>
+    </ClCompile>
     <ClCompile Include="..\libs\core\exception.cpp" />
     <ClCompile Include="..\libs\core\log.cpp" />
     <ClCompile Include="..\libs\core\matrix.cpp">

--- a/msvc/fixmd2.vcxproj
+++ b/msvc/fixmd2.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -51,57 +51,57 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -193,17 +193,17 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\boost_1_49_0\stage\lib\x64;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\boost_1_49_0\stage\lib\x64;$(LibraryPath)</LibraryPath>
@@ -213,12 +213,15 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Sync</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -291,11 +294,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -305,13 +308,14 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <CompileAs>CompileAsCpp</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
       <FloatingPointModel>Strict</FloatingPointModel>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>false</GenerateDebugInformation>

--- a/msvc/glvis.vcxproj
+++ b/msvc/glvis.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -51,57 +51,57 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -193,17 +193,17 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\boost_1_49_0\stage\lib\x64;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\boost_1_49_0\stage\lib\x64;$(LibraryPath)</LibraryPath>
@@ -213,11 +213,14 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -275,11 +278,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
@@ -288,13 +291,14 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <CompileAs>CompileAsCpp</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
       <FloatingPointModel>Strict</FloatingPointModel>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>false</GenerateDebugInformation>

--- a/msvc/gme.vcxproj
+++ b/msvc/gme.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -227,57 +227,57 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -365,7 +365,7 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
@@ -376,11 +376,14 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
       <OutputFile>$(OutDir)$(ProjectName)_d.lib</OutputFile>
@@ -428,11 +431,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -441,13 +444,14 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Fast</FloatingPointModel>
       <CompileAs>CompileAsCpp</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">

--- a/msvc/libglbsp.vcxproj
+++ b/msvc/libglbsp.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -52,66 +52,66 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -209,27 +209,29 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">F:\Libraries\include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">F:\Libraries\include;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">F:\Libraries\Debug;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">F:\Libraries\Debug;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>GLBSP_PLUGIN;WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <MinimalRebuild>false</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -308,11 +310,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <PreprocessorDefinitions>GLBSP_PLUGIN;WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -323,12 +325,13 @@
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <CallingConvention>Cdecl</CallingConvention>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <CompileAs>CompileAsCpp</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
       <FloatingPointModel>Strict</FloatingPointModel>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/msvc/libglvis.vcxproj
+++ b/msvc/libglvis.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -51,67 +51,67 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -209,7 +209,7 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
@@ -222,11 +222,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
@@ -237,13 +237,14 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <CompileAs>CompileAsCpp</CompileAs>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
       <FloatingPointModel>Strict</FloatingPointModel>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -421,12 +422,15 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/msvc/timidity.vcxproj
+++ b/msvc/timidity.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -51,67 +51,67 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -209,7 +209,7 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
@@ -218,11 +218,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -234,12 +234,13 @@
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Fast</FloatingPointModel>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -419,12 +420,15 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/msvc/vavoom-master.vcxproj
+++ b/msvc/vavoom-master.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -52,57 +52,57 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -200,13 +200,13 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
@@ -220,13 +220,16 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -306,11 +309,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
@@ -322,11 +325,12 @@
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <CallingConvention>Cdecl</CallingConvention>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/msvc/vavoom.vcxproj
+++ b/msvc/vavoom.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -51,67 +51,67 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -219,29 +219,29 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msv;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msv;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msv;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win64\api\inc;C:\Libraries\include64;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\lib;F:\Libraries\OpenAL 1.1 SDK\libs\Win32;F:\Libraries\Release;F:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;F:\Libraries\wxWidgets-2.8.12\lib\vc_lib;F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\lib;E:\Libraries\OpenAL 1.1 SDK\libs\Win32;E:\Libraries\Release;E:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;E:\Libraries\wxWidgets-2.8.12\lib\vc_lib;E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\lib;F:\Libraries\OpenAL 1.1 SDK\libs\Win32;F:\Libraries\Release;F:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;F:\Libraries\wxWidgets-2.8.12\lib\vc_lib;F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\lib;F:\Libraries\OpenAL 1.1 SDK\libs\Win64;F:\Libraries\Release64;F:\Libraries\Release;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;F:\Libraries\wxWidgets-2.8.12\lib\vc_lib;F:\Libraries\boost_1_49_0\stage\lib\x64;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\lib;F:\Libraries\OpenAL 1.1 SDK\libs\Win64;F:\Libraries\Release64;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;F:\Libraries\wxWidgets-2.8.12\lib\vc_lib;F:\Libraries\boost_1_49_0\stage\lib\x64;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\lib;C:\Libraries\OpenAL 1.1 SDK\libs\Win32;C:\Libraries\Release;C:\Libraries\Debug;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x86;C:\Libraries\wxWidgets-2.8.12\lib\vc_lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win64\api\lib;C:\Libraries\OpenAL 1.1 SDK\libs\Win64;C:\Libraries\Release64;C:\Libraries\Debug64;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Lib\x64;C:\Libraries\wxWidgets-2.8.12\lib\vc_lib;$(LibraryPath)</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">F:\Libraries\include;F:\Libraries\OpenAL 1.1 SDK\include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\include;E:\Libraries\OpenAL 1.1 SDK\include;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">F:\Libraries\include;F:\Libraries\OpenAL 1.1 SDK\include;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">F:\Libraries\Debug;F:\Libraries\OpenAL 1.1 SDK\libs\Win32;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\Debug;E:\Libraries\OpenAL 1.1 SDK\libs\Win32;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">F:\Libraries\Debug;F:\Libraries\OpenAL 1.1 SDK\libs\Win32;$(LibraryPath)</LibraryPath>
-    <ExecutablePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
+    <ExecutablePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
     <ExecutablePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
     <ExecutablePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
     <ExecutablePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ExecutablePath>F:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
+    <ExecutablePath>E:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">
     <ExecutablePath>F:\Libraries\bin;$(ExecutablePath)</ExecutablePath>
@@ -267,11 +267,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <PreprocessorDefinitions>NDEBUG;WIN32;_WINDOWS;MIKMOD_STATIC;MODPLUG_STATIC;FLAC__NO_DLL;_CRT_SECURE_NO_DEPRECATE;USE_ASM_I386=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -281,17 +281,18 @@
       </BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <EnablePREfast>false</EnablePREfast>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -682,7 +683,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_WIN32;_CRTDBG_MAP_ALLOC;MIKMOD_STATIC;MODPLUG_STATIC;FLAC__NO_DLL;_CRT_SECURE_NO_DEPRECATE;USE_ASM_I386=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -690,9 +691,10 @@
       </BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <CompileAs>Default</CompileAs>
-      <MultiProcessorCompilation>false</MultiProcessorCompilation>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/msvc/vcc.vcxproj
+++ b/msvc/vcc.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -52,66 +52,66 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -213,13 +213,13 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;E:\Libraries\wxWidgets-2.8.12\include\msvc;E:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">C:\Libraries\boost_1_49_0\;$(IncludePath)</IncludePath>
@@ -238,12 +238,15 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;IN_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -368,11 +371,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;IN_VCC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
@@ -380,15 +383,16 @@
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
       <FloatingPointModel>Strict</FloatingPointModel>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/msvc/vlumpy.vcxproj
+++ b/msvc/vlumpy.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug64|Win32">
       <Configuration>Debug64</Configuration>
@@ -51,67 +51,67 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -219,17 +219,17 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release64|x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'" />
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\FMOD Programmers API Win32\api\inc;E:\Libraries\include;E:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;E:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.11\include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\FMOD Programmers API Win32\api\inc;F:\Libraries\include64;F:\Libraries\include;F:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;F:\Libraries\wxWidgets-2.8.12\include\msvc;F:\Libraries\boost_1_49_0;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|Win32'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Release x64|x64'">C:\Libraries\FMOD Programmers API Win32\api\inc;C:\Libraries\include;C:\Program Files (x86)\Microsoft DirectX SDK (June 2010)\Include;C:\Libraries\wxWidgets-2.8.11\include;C:\Libraries\wxWidgets-2.8.12\include\msvc;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\Libraries\Release;F:\Libraries\Debug;F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">E:\Libraries\Release;E:\Libraries\Debug;E:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|Win32'">F:\Libraries\Release;F:\Libraries\Debug;F:\Libraries\boost_1_49_0\stage\lib;$(LibraryPath)</LibraryPath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">F:\Libraries\include;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\include;$(IncludePath)</IncludePath>
     <IncludePath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">F:\Libraries\include;$(IncludePath)</IncludePath>
-    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">F:\Libraries\Debug;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">E:\Libraries\Debug;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug64|Win32'">F:\Libraries\Debug;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">F:\Libraries\boost_1_49_0\stage\lib\x64;F:\Libraries\Release64;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release64|x64'">F:\Libraries\boost_1_49_0\stage\lib\x64;F:\Libraries\Release64;$(LibraryPath)</LibraryPath>
@@ -241,11 +241,11 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>MaxSpeed</Optimization>
+      <Optimization>Full</Optimization>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>true</OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
@@ -257,10 +257,11 @@
       <CallingConvention>Cdecl</CallingConvention>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Qpar-report:1 /Qvec-report:1 /Gw /MP /Oy- %(AdditionalOptions)</AdditionalOptions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <EnableParallelCodeGeneration>true</EnableParallelCodeGeneration>
       <OpenMPSupport>false</OpenMPSupport>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -521,12 +522,15 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../utils/common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
+      <SDLCheck>false</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/progs/common/engine/Entity.vc
+++ b/progs/common/engine/Entity.vc
@@ -219,6 +219,7 @@ byte			SpriteType;				//  How to draw sprite
 name			FixedSpriteName;
 string			FixedModelName;
 byte			ModelVersion;
+int             NumTouchingLights;
 
 byte			RenderStyle;
 float			Alpha;
@@ -333,9 +334,9 @@ replication
 {
 	reliable if (Role == ROLE_Authority)
 		Origin, Angles, FloorClip, State, StateTime, SpriteType,
-		FixedSpriteName, ModelVersion, RenderStyle, Alpha, Translation,
-		ScaleX, ScaleY, bFly, bNoSector, bInvisible, bFullBright, bFixedModel,
-		SoundOriginID, bUseDispState, bBright;
+		FixedSpriteName, ModelVersion, NumTouchingLights, RenderStyle, Alpha,
+		Translation, ScaleX, ScaleY, bFly, bNoSector, bInvisible, bFullBright,
+		bFixedModel, SoundOriginID, bUseDispState, bBright;
 
 	reliable if (Role == ROLE_Authority && bUseDispState)
 		DispState;

--- a/source/am_map.cpp
+++ b/source/am_map.cpp
@@ -1702,9 +1702,9 @@ static vuint32 StringToColour(const char *str)
 	int r, g, b;
 	char *p;
 
-	r = strtol(str, &p, 16) & 0xff;
-	g = strtol(p, &p, 16) & 0xff;
-	b = strtol(p, &p, 16) & 0xff;
+	r = strtol(str, &p, 16) & 255;
+	g = strtol(p, &p, 16) & 255;
+	b = strtol(p, &p, 16) & 255;
 	return 0xff000000 | (r << 16) | (g << 8) | b;
 }
 

--- a/source/cmd.cpp
+++ b/source/cmd.cpp
@@ -192,8 +192,14 @@ void VCommand::Shutdown()
 	{
 		VAlias* Next = a->Next;
 		delete a;
-		a = NULL;
-		a = Next;
+		if (Next)
+		{
+			a = Next;
+		}
+		else
+		{
+			a = NULL;
+		}
 	}
 	AutoCompleteTable.Clear();
 	Args.Clear();

--- a/source/d3d_local.h
+++ b/source/d3d_local.h
@@ -162,7 +162,7 @@ public:
 		const TVec&);
 	void DrawAliasModel(const TVec&, const TAVec&, const TVec&, const TVec&,
 		VMeshModel*, int, int, VTexture*, VTextureTranslation*, int, vuint32,
-		vuint32, float, bool, bool, float, bool);
+		vuint32, float, bool, bool, float, bool, bool);
 	bool StartPortal(VPortal*, bool);
 	void EndPortal(VPortal*, bool);
 
@@ -194,9 +194,9 @@ public:
 	void DrawWorldAmbientPass();
 	void BeginShadowVolumesPass();
 	void BeginLightShadowVolumes();
-	void RenderSurfaceShadowVolume(surface_t*, TVec&, float);
+	void RenderSurfaceShadowVolume(surface_t*, TVec&, float, bool);
 	void BeginLightPass(TVec&, float, vuint32);
-	void DrawSurfaceLight(surface_t*, TVec&, float);
+	void DrawSurfaceLight(surface_t*, TVec&, float, bool);
 	void DrawWorldTexturesPass();
 	void DrawWorldFogPass();
 	void EndFogPass();
@@ -204,7 +204,7 @@ public:
 		const TVec&, VMeshModel*, int, int, VTexture*, vuint32, float, float, bool);
 	void DrawAliasModelTextures(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, VTextureTranslation*, int,
-		float, float, bool);
+		float, float, bool, bool);
 	void BeginModelsLightPass(TVec&, float, vuint32);
 	void DrawAliasModelLight(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, float, bool);
@@ -297,6 +297,7 @@ private:
 	static VCvarI model_lighting;
 	static VCvarI specular_highlights;
 	static VCvarI avoid_input_lag;
+	static VCvarI multisampling_sample;
 };
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------

--- a/source/d3d_main.cpp
+++ b/source/d3d_main.cpp
@@ -53,6 +53,7 @@ VCvarF VDirect3DDrawer::maxdist("d3d_maxdist", "8192.0", CVAR_Archive);
 VCvarI VDirect3DDrawer::model_lighting("d3d_model_lighting", "0", CVAR_Archive);
 VCvarI VDirect3DDrawer::specular_highlights("d3d_specular_highlights", "1", CVAR_Archive);
 VCvarI VDirect3DDrawer::avoid_input_lag("d3d_avoid_input_lag", "1", CVAR_Archive);
+VCvarI VDirect3DDrawer::multisampling_sample("d3d_multisampling_sample", "1", CVAR_Archive);
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 
@@ -336,9 +337,9 @@ void VDirect3DDrawer::StartUpdate()
 		}
 		case 2:
 		{
-			magfilter = D3DTEXF_LINEAR;
-			minfilter = D3DTEXF_LINEAR;
-			mipfilter = D3DTEXF_POINT;
+			magfilter = D3DTEXF_POINT;
+			minfilter = D3DTEXF_POINT;
+			mipfilter = D3DTEXF_LINEAR;
 			break;
 		}
 		case 3:
@@ -354,6 +355,12 @@ void VDirect3DDrawer::StartUpdate()
 			minfilter = D3DTEXF_ANISOTROPIC;
 			mipfilter = D3DTEXF_LINEAR;
 			break;
+		}
+		case 5:
+		{
+			magfilter = D3DTEXF_POINT;
+			minfilter = D3DTEXF_ANISOTROPIC;
+			mipfilter = D3DTEXF_LINEAR;
 		}
 		default:
 		{
@@ -931,9 +938,9 @@ bool VDirect3DDrawer::SupportsAdvancedRendering()
 void VDirect3DDrawer::DrawWorldAmbientPass() {}
 void VDirect3DDrawer::BeginShadowVolumesPass() {}
 void VDirect3DDrawer::BeginLightShadowVolumes() {}
-void VDirect3DDrawer::RenderSurfaceShadowVolume(surface_t*, TVec&, float) {}
+void VDirect3DDrawer::RenderSurfaceShadowVolume(surface_t*, TVec&, float, bool) {}
 void VDirect3DDrawer::BeginLightPass(TVec&, float, vuint32) {}
-void VDirect3DDrawer::DrawSurfaceLight(surface_t*, TVec&, float) {}
+void VDirect3DDrawer::DrawSurfaceLight(surface_t*, TVec&, float, bool) {}
 void VDirect3DDrawer::DrawWorldTexturesPass() {}
 void VDirect3DDrawer::DrawWorldFogPass() {}
 void VDirect3DDrawer::EndFogPass() {}
@@ -941,7 +948,7 @@ void VDirect3DDrawer::DrawAliasModelAmbient(const TVec&, const TAVec&, const TVe
 	const TVec&, VMeshModel*, int, int, VTexture*, vuint32, float, float, bool) {}
 void VDirect3DDrawer::DrawAliasModelTextures(const TVec&, const TAVec&, const TVec&,
 	const TVec&, VMeshModel*, int, int, VTexture*, VTextureTranslation*, int,
-	float, float, bool) {}
+	float, float, bool, bool) {}
 void VDirect3DDrawer::BeginModelsLightPass(TVec&, float, vuint32) {}
 void VDirect3DDrawer::DrawAliasModelLight(const TVec&, const TAVec&, const TVec&,
 	const TVec&, VMeshModel*, int, int, VTexture*, float, bool) {}

--- a/source/d3d_tex.cpp
+++ b/source/d3d_tex.cpp
@@ -406,10 +406,10 @@ LPDIRECT3DTEXTURE9 VDirect3DDrawer::UploadTexture(int width, int height, const r
 	}
 	if (w != width || h != height)
 	{
-		// Smooth transparent edges
-		VTexture::SmoothEdges((vuint8*)data, width, height, (vuint8*)data);
 		//	Must rescale image to get "top" mipmap texture image
-		VTexture::ResampleTexture(width, height, (vuint8*)data, w, h, image);
+		VTexture::ResampleTexture(width, height, (vuint8*)data, w, h, image, multisampling_sample);
+		// Smooth transparent edges
+		VTexture::SmoothEdges(image, w, h, image);
 	}
 	else
 	{

--- a/source/drawer.h
+++ b/source/drawer.h
@@ -157,7 +157,7 @@ public:
 		const TVec&, const TVec&, const TVec&) = 0;
 	virtual void DrawAliasModel(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, VTextureTranslation*, int,
-		vuint32, vuint32, float, bool, bool, float, bool) = 0;
+		vuint32, vuint32, float, bool, bool, float, bool, bool) = 0;
 	virtual bool StartPortal(VPortal*, bool) = 0;
 	virtual void EndPortal(VPortal*, bool) = 0;
 
@@ -189,9 +189,9 @@ public:
 	virtual void DrawWorldAmbientPass() = 0;
 	virtual void BeginShadowVolumesPass() = 0;
 	virtual void BeginLightShadowVolumes() = 0;
-	virtual void RenderSurfaceShadowVolume(surface_t*, TVec&, float) = 0;
+	virtual void RenderSurfaceShadowVolume(surface_t*, TVec&, float, bool) = 0;
 	virtual void BeginLightPass(TVec&, float, vuint32) = 0;
-	virtual void DrawSurfaceLight(surface_t*, TVec&, float) = 0;
+	virtual void DrawSurfaceLight(surface_t*, TVec&, float, bool) = 0;
 	virtual void DrawWorldTexturesPass() = 0;
 	virtual void DrawWorldFogPass() = 0;
 	virtual void EndFogPass() = 0;
@@ -199,7 +199,7 @@ public:
 		const TVec&, VMeshModel*, int, int, VTexture*, vuint32, float, float, bool) = 0;
 	virtual void DrawAliasModelTextures(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, VTextureTranslation*, int,
-		float, float, bool) = 0;
+		float, float, bool, bool) = 0;
 	virtual void BeginModelsLightPass(TVec&, float, vuint32) = 0;
 	virtual void DrawAliasModelLight(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, float, bool) = 0;

--- a/source/gl_draw.cpp
+++ b/source/gl_draw.cpp
@@ -198,8 +198,8 @@ void VOpenGLDrawer::FillRect(float x1, float y1, float x2, float y2,
 	if (HaveShaders)
 	{
 		p_glUseProgramObjectARB(DrawFixedColProgram);
-		p_glUniform4fARB(DrawFixedColColourLoc, ((colour >> 16) & 0xff) / 255.0,
-			((colour >> 8) & 0xff) / 255.0, (colour & 0xff) / 255.0, 1.0);
+		p_glUniform4fARB(DrawFixedColColourLoc, (GLfloat)(((colour >> 16) & 255) / 255.0),
+			(GLfloat)(((colour >> 8) & 255) / 255.0), (GLfloat)((colour & 255) / 255.0), 1.0);
 	}
 	else
 	{

--- a/source/gl_local.h
+++ b/source/gl_local.h
@@ -370,9 +370,9 @@ public:
 	void DrawWorldAmbientPass();
 	void BeginShadowVolumesPass();
 	void BeginLightShadowVolumes();
-	void RenderSurfaceShadowVolume(surface_t *surf, TVec& LightPos, float Radius);
+	void RenderSurfaceShadowVolume(surface_t *, TVec&, float, bool);
 	void BeginLightPass(TVec&, float, vuint32);
-	void DrawSurfaceLight(surface_t*, TVec&, float);
+	void DrawSurfaceLight(surface_t*, TVec&, float, bool);
 	void DrawWorldTexturesPass();
 	void DrawWorldFogPass();
 	void EndFogPass();
@@ -384,11 +384,11 @@ public:
 		const TVec&);
 	void DrawAliasModel(const TVec&, const TAVec&, const TVec&, const TVec&,
 		VMeshModel*, int, int, VTexture*, VTextureTranslation*, int, vuint32,
-		vuint32, float, bool, bool, float, bool);
+		vuint32, float, bool, bool, float, bool, bool);
 	void DrawAliasModelAmbient(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, vuint32, float, float, bool);
 	void DrawAliasModelTextures(const TVec&, const TAVec&, const TVec&, const TVec&,
-		VMeshModel*, int, int, VTexture*, VTextureTranslation*, int, float, float, bool);
+		VMeshModel*, int, int, VTexture*, VTextureTranslation*, int, float, float, bool, bool);
 	void BeginModelsLightPass(TVec&, float, vuint32);
 	void DrawAliasModelLight(const TVec&, const TAVec&, const TVec&,
 		const TVec&, VMeshModel*, int, int, VTexture*, float, bool);
@@ -576,6 +576,7 @@ protected:
 	GLint					ShadowsLightTexIWLoc;
 	GLint					ShadowsLightTexIHLoc;
 	GLint					ShadowsLightTextureLoc;
+	GLint					ShadowsLightLightViewOrigin;
 
 	GLhandleARB				ShadowsTextureProgram;
 	GLint					ShadowsTextureTexCoordLoc;
@@ -610,6 +611,7 @@ protected:
 	GLint					ShadowsModelLightVertNormalLoc;
 	GLint					ShadowsModelLightVert2NormalLoc;
 	GLint					ShadowsModelLightTexCoordLoc;
+	GLint					ShadowsModelLightViewOrigin;
 
 	GLhandleARB				ShadowsModelShadowProgram;
 	GLint					ShadowsModelShadowInterLoc;
@@ -652,6 +654,7 @@ protected:
 	static VCvarF maxdist;
 	static VCvarI model_lighting;
 	static VCvarI specular_highlights;
+	static VCvarI multisampling_sample;
 
 	//	Extensions
 	bool CheckExtension(const char*);
@@ -802,8 +805,8 @@ protected:
 
 	static void SetColour(vuint32 c)
 	{
-		glColor4ub(byte((c >> 16) & 0xff), byte((c >> 8) & 0xff),
-			byte(c & 0xff), byte(c >> 24));
+		glColor4ub(byte((c >> 16) & 255), byte((c >> 8) & 255),
+			byte(c & 255), byte(c >> 24));
 	}
 };
 

--- a/source/gl_poly.cpp
+++ b/source/gl_poly.cpp
@@ -83,8 +83,7 @@ void VOpenGLDrawer::WorldDrawing()
 	{
 		for (surf = RendLev->HorizonPortalsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -102,8 +101,7 @@ void VOpenGLDrawer::WorldDrawing()
 		glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 		for (surf = RendLev->SkyPortalsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -125,8 +123,7 @@ void VOpenGLDrawer::WorldDrawing()
 	{
 		for (surf = RendLev->SimpleSurfsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -192,8 +189,7 @@ void VOpenGLDrawer::WorldDrawing()
 			for (cache = RendLev->light_chain[lb]; cache; cache = cache->chain)
 			{
 				surf = cache->surf;
-				float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-				if (dist <= 0)
+				if (surf->plane->PointOnSide(vieworg))
 				{
 					//	Viewer is in back side or on plane
 					continue;
@@ -252,8 +248,7 @@ void VOpenGLDrawer::WorldDrawing()
 			for (cache = RendLev->light_chain[lb]; cache; cache = cache->chain)
 			{
 				surf = cache->surf;
-				float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-				if (dist <= 0)
+				if (surf->plane->PointOnSide(vieworg))
 				{
 					//	Viewer is in back side or on plane
 					continue;
@@ -299,8 +294,8 @@ void VOpenGLDrawer::WorldDrawing()
 			}
 
 			glBindTexture(GL_TEXTURE_2D, addmap_id[lb]);
-			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minfilter);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
 
 			if (RendLev->add_changed[lb])
 			{
@@ -312,8 +307,7 @@ void VOpenGLDrawer::WorldDrawing()
 			for (cache = RendLev->add_chain[lb]; cache; cache = cache->addchain)
 			{
 				surf = cache->surf;
-				float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-				if (dist <= 0)
+				if (surf->plane->PointOnSide(vieworg))
 				{
 					//	Viewer is in back side or on plane
 					continue;
@@ -359,8 +353,7 @@ void VOpenGLDrawer::WorldDrawingShaders()
 	{
 		for (surf = RendLev->HorizonPortalsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -378,8 +371,7 @@ void VOpenGLDrawer::WorldDrawingShaders()
 		glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 		for (surf = RendLev->SkyPortalsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -404,8 +396,7 @@ void VOpenGLDrawer::WorldDrawingShaders()
 
 		for (surf = RendLev->SimpleSurfsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -491,8 +482,7 @@ void VOpenGLDrawer::WorldDrawingShaders()
 		for (cache = RendLev->light_chain[lb]; cache; cache = cache->chain)
 		{
 			surf = cache->surf;
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -552,8 +542,7 @@ void VOpenGLDrawer::DrawWorldAmbientPass()
 	{
 		for (surface_t* surf = RendLev->HorizonPortalsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -569,8 +558,7 @@ void VOpenGLDrawer::DrawWorldAmbientPass()
 		glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 		for (surface_t* surf = RendLev->SkyPortalsHead; surf; surf = surf->DrawNext)
 		{
-			float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-			if (dist <= 0)
+			if (surf->plane->PointOnSide(vieworg))
 			{
 				//	Viewer is in back side or on plane
 				continue;
@@ -590,8 +578,7 @@ void VOpenGLDrawer::DrawWorldAmbientPass()
 	p_glUniform1iARB(ShadowsAmbientTextureLoc, 0);
 	for (surface_t* surf = RendLev->SimpleSurfsHead; surf; surf = surf->DrawNext)
 	{
-		float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-		if (dist <= 0)
+		if (surf->plane->PointOnSide(vieworg))
 		{
 			//	Viewer is in back side or on plane
 			continue;
@@ -648,8 +635,8 @@ void VOpenGLDrawer::BeginLightShadowVolumes()
 	//	Set up for shadow volume rendering.
 	glClear(GL_STENCIL_BUFFER_BIT);
 	glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
-	//glEnable(GL_POLYGON_OFFSET_FILL);
-	//glPolygonOffset(0.0f, 10.0f);
+	glEnable(GL_POLYGON_OFFSET_FILL);
+	glPolygonOffset(1.0f, 10.0f);
 	glDepthFunc(GL_LESS);
 
 	glDisable(GL_BLEND);
@@ -668,18 +655,13 @@ void VOpenGLDrawer::BeginLightShadowVolumes()
 //
 //==========================================================================
 
-void VOpenGLDrawer::RenderSurfaceShadowVolume(surface_t *surf, TVec& LightPos, float Radius)
+void VOpenGLDrawer::RenderSurfaceShadowVolume(surface_t *surf, TVec& LightPos, float Radius, bool LightCanCross)
 {
 	guard(VOpenGLDrawer::RenderSurfaceShadowVolume);
 	int i;
 	TArray<TVec>    v;
-	if (surf->plane->PointOnSide(LightPos))
-	{
-		//	Light is in back side or on plane
-		return;
-	}
 	float dist = DotProduct(LightPos, surf->plane->normal) - surf->plane->dist;
-	if (dist >= Radius)
+	if ((dist <= 0.0 && !LightCanCross) || dist < -Radius || dist > Radius)
 	{
 		//	Light is too far away
 		return;
@@ -728,9 +710,9 @@ void VOpenGLDrawer::RenderSurfaceShadowVolume(surface_t *surf, TVec& LightPos, f
 void VOpenGLDrawer::BeginLightPass(TVec& LightPos, float Radius, vuint32 Colour)
 {
 	guard(VOpenGLDrawer::BeginLightPass);
-	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glDisable(GL_POLYGON_OFFSET_FILL);
 	glDepthFunc(GL_LEQUAL);
+	glDisable(GL_POLYGON_OFFSET_FILL);
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
 	glStencilFunc(GL_EQUAL, 0x0, 0xff);
 	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
@@ -754,16 +736,16 @@ void VOpenGLDrawer::BeginLightPass(TVec& LightPos, float Radius, vuint32 Colour)
 //
 //==========================================================================
 
-void VOpenGLDrawer::DrawSurfaceLight(surface_t* Surf, TVec& LightPos, float Radius)
+void VOpenGLDrawer::DrawSurfaceLight(surface_t* Surf, TVec& LightPos, float Radius, bool LightCanCross)
 {
 	guard(VOpenGLDrawer::DrawSurfaceLight);
-	if (Surf->plane->PointOnSide(LightPos))
+	if (Surf->plane->PointOnSide(vieworg))
 	{
-		//	Light is in back side or on plane
+		//	Viewer is in back side or on plane
 		return;
 	}
 	float dist = DotProduct(LightPos, Surf->plane->normal) - Surf->plane->dist;
-	if (dist >= Radius)
+	if ((dist <= 0.0 && !LightCanCross) || dist < -Radius || dist > Radius)
 	{
 		//	Light is too far away
 		return;
@@ -777,12 +759,13 @@ void VOpenGLDrawer::DrawSurfaceLight(surface_t* Surf, TVec& LightPos, float Radi
 	p_glUniform3fvARB(ShadowsAmbientTAxisLoc, 1, &tex->taxis.x);
 	p_glUniform1fARB(ShadowsAmbientTOffsLoc, tex->toffs);
 	p_glUniform1fARB(ShadowsAmbientTexIHLoc, tex_ih);
+	p_glVertexAttrib3fvARB(ShadowsLightSurfNormalLoc, &Surf->plane->normal.x);
+	p_glVertexAttrib1fvARB(ShadowsLightSurfDistLoc, &Surf->plane->dist);
+	p_glVertexAttrib3fvARB(ShadowsLightLightViewOrigin, &vieworg.x);
 
 	glBegin(GL_POLYGON);
 	for (int i = 0; i < Surf->count; i++)
 	{
-		p_glVertexAttrib3fvARB(ShadowsLightSurfNormalLoc, &Surf->plane->normal.x);
-		p_glVertexAttrib1fvARB(ShadowsLightSurfDistLoc, &Surf->plane->dist);
 		glVertex(Surf->verts[i]);
 	}
 	glEnd();
@@ -809,8 +792,7 @@ void VOpenGLDrawer::DrawWorldTexturesPass()
 
 	for (surface_t* surf = RendLev->SimpleSurfsHead; surf; surf = surf->DrawNext)
 	{
-		float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-		if (dist <= 0)
+		if (surf->plane->PointOnSide(vieworg))
 		{
 			//	Viewer is in back side or on plane
 			continue;
@@ -848,14 +830,14 @@ void VOpenGLDrawer::DrawWorldFogPass()
 
 	for (surface_t* surf = RendLev->SimpleSurfsHead; surf; surf = surf->DrawNext)
 	{
-		float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-		if (dist <= 0)
-		{
-			//	Viewer is in back side or on plane
-			continue;
-		}
 		if (!surf->Fade)
 		{
+			continue;
+		}
+
+		if (surf->plane->PointOnSide(vieworg))
+		{
+			//	Viewer is in back side or on plane
 			continue;
 		}
 
@@ -1191,8 +1173,7 @@ void VOpenGLDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 	bool Additive)
 {
 	guard(VOpenGLDrawer::DrawMaskedPolygon);
-	float dist = DotProduct(vieworg, surf->plane->normal) - surf->plane->dist;
-	if (dist <= 0)
+	if (surf->plane->PointOnSide(vieworg))
 	{
 		//	Viewer is in back side or on plane
 		return;
@@ -1513,7 +1494,7 @@ void VOpenGLDrawer::StartParticles()
 	else
 	{
 		glEnable(GL_ALPHA_TEST);
-		glAlphaFunc(GL_GREATER, 0.0);
+		glAlphaFunc(GL_GREATER, 0.111);
 		if (pointparmsable)
 		{
 			GLfloat parms[3] = { 0.0, 1.0, 0.0 };
@@ -1571,10 +1552,14 @@ void VOpenGLDrawer::DrawParticle(particle_t *p)
 		}
 		else
 		{
-			glTexCoord2f(0, 0); glVertex(p->org - viewright * p->Size + viewup * p->Size);
-			glTexCoord2f(1, 0); glVertex(p->org + viewright * p->Size + viewup * p->Size);
-			glTexCoord2f(1, 1); glVertex(p->org + viewright * p->Size - viewup * p->Size);
-			glTexCoord2f(0, 1); glVertex(p->org - viewright * p->Size - viewup * p->Size);
+			glTexCoord2f(0, 0);
+			glVertex(p->org - viewright * p->Size + viewup * p->Size);
+			glTexCoord2f(1, 0);
+			glVertex(p->org + viewright * p->Size + viewup * p->Size);
+			glTexCoord2f(1, 1);
+			glVertex(p->org + viewright * p->Size - viewup * p->Size);
+			glTexCoord2f(0, 1);
+			glVertex(p->org - viewright * p->Size - viewup * p->Size);
 		}
 	}
 	unguard;

--- a/source/gl_win32.cpp
+++ b/source/gl_win32.cpp
@@ -138,7 +138,8 @@ bool VWin32OpenGLDrawer::SetResolution(int AWidth, int AHeight, int ABPP,
 	//	Create window
 	RenderWindow = CreateWindow("VAVOOM", "VAVOOM for Windows",
 		Windowed ? (WS_OVERLAPPEDWINDOW & ~WS_MAXIMIZEBOX) |
-		WS_CLIPCHILDREN | WS_CLIPSIBLINGS : WS_POPUP,
+		WS_CLIPCHILDREN | WS_CLIPSIBLINGS : WS_POPUP | 
+		WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
 		0, 0, 2, 2, hwnd, NULL, hInst, NULL);
 	if (!RenderWindow)
 	{
@@ -271,7 +272,7 @@ bool VWin32OpenGLDrawer::SetResolution(int AWidth, int AHeight, int ABPP,
 		GCon->Log(NAME_Init, "Swap control extension found.");
 		typedef bool (APIENTRY *PFNWGLSWAPINTERVALFARPROC)(int);
 
-		PFNWGLSWAPINTERVALFARPROC wglSwapIntervalEXT = 0;
+		PFNWGLSWAPINTERVALFARPROC wglSwapIntervalEXT;
 
 		wglSwapIntervalEXT = (PFNWGLSWAPINTERVALFARPROC)GetExtFuncPtr("wglSwapIntervalEXT");
 

--- a/source/host.cpp
+++ b/source/host.cpp
@@ -115,10 +115,10 @@ static VCvarS	Language("language", "en", CVAR_Archive);
 void Host_PrintVersion()
 {
 	dprintf("%s\n", "VAVOOM version " VERSION_TEXT" (r" SVN_REVISION_STRING ").");
-#ifdef SPECIAL_VERSION_TEXT
-	dprintf("%s\n", SPECIAL_VERSION_TEXT".");
-#endif
-	dprintf("%s\n", "Compiled "__DATE__" "__TIME__".");
+	#ifdef SPECIAL_VERSION_TEXT
+		dprintf("%s\n", SPECIAL_VERSION_TEXT".");
+	#endif
+		dprintf("%s\n", "Compiled " __DATE__" " __TIME__".");
 }
 
 //==========================================================================
@@ -150,14 +150,15 @@ void Host_Init()
 #else
 	OpenDebugFile("basev/debug.txt");
 #endif
-	Host_PrintVersion();
-	dprintf("Running Host_Init\n");
 
    // Seed the random-number generator with the current time so that
    // the numbers will be different every time we run.
    srand((unsigned)time(NULL));
 
-	// init subsystems
+   Host_PrintVersion();
+   dprintf("Running Host_Init\n");
+   
+   // init subsystems
 
 	M_InitByteOrder();
 
@@ -375,9 +376,6 @@ void Host_Frame()
 
 	try
 	{
-		//	Keep the random time dependent
-		rand();
-
 		//	Decide the simulation time
 		if (!FilterTime())
 		{
@@ -566,10 +564,7 @@ void Host_Error(const char *error, ...)
 COMMAND(Version)
 {
 	GCon->Log("VAVOOM version " VERSION_TEXT" (r" SVN_REVISION_STRING ").");
-#ifdef SPECIAL_VERSION_TEXT
-	GCon->Log(SPECIAL_VERSION_TEXT".");
-#endif
-	GCon->Log("Compiled "__DATE__" "__TIME__".");
+	GCon->Log("Compiled " __DATE__ " " __TIME__ ".");
 }
 
 //==========================================================================

--- a/source/level.cpp
+++ b/source/level.cpp
@@ -464,8 +464,14 @@ void VLevel::Destroy()
 			{
 				polyblock_t* Next = pb->next;
 				delete pb;
-				pb = NULL;
-				pb = Next;
+				if (Next)
+				{
+					pb = Next;
+				}
+				else
+				{
+					pb = NULL;
+				}
 			}
 		}
 		delete[] PolyBlockMap;

--- a/source/net_channel.cpp
+++ b/source/net_channel.cpp
@@ -83,15 +83,27 @@ VChannel::~VChannel()
 	{
 		VMessageIn* Next = Msg->Next;
 		delete Msg;
-		Msg = NULL;
-		Msg = Next;
+		if (Next)
+		{
+			Msg = Next;
+		}
+		else
+		{
+			Msg = NULL;
+		}
 	}
 	for (VMessageOut* Msg = OutMsg; Msg; )
 	{
 		VMessageOut* Next = Msg->Next;
 		delete Msg;
-		Msg = NULL;
-		Msg = Next;
+		if (Next)
+		{
+			Msg = Next;
+		}
+		else
+		{
+			Msg = NULL;
+		}
 	}
 	if (Index != -1 && Connection->Channels[Index] == this)
 	{

--- a/source/net_connection.cpp
+++ b/source/net_connection.cpp
@@ -167,7 +167,7 @@ void VNetConnection::GetMessages()
 				vuint8 LastByte = Data[Data.Num() - 1];
 				if (LastByte)
 				{
-					//	Find out real length by stepping back untill the trailing bit.
+					//	Find out real length by stepping back until the trailing bit.
 					vuint32 Length = Data.Num() * 8 - 1;
 					for (vuint8 Mask = 0x80; !(LastByte & Mask); Mask >>= 1)
 					{
@@ -614,7 +614,7 @@ void VNetConnection::SendCommand(VStr Str)
 void VNetConnection::SetUpFatPVS()
 {
 	guard(VNetConnection::SetUpFatPVS);
-	float	dummy_bbox[6] = {-99999, -99999, -99999, 99999, 99999, 99999};
+	float	dummy_bbox[6] = { -99999, -99999, -99999, 99999, 99999, 99999 };
 	VLevel*	Level = Context->GetLevel();
 
 	LeafPvs = Level->LeafPVS(Owner->MO->SubSector);

--- a/source/p_clip.h
+++ b/source/p_clip.h
@@ -51,6 +51,7 @@ public:
 	bool ClipIsFull();
 	float PointToClipAngle(const TVec&);
 	bool ClipIsBBoxVisible(float*);
+	bool ClipCheckRegion(subregion_t*, subsector_t*);
 	bool ClipCheckSubsector(subsector_t*);
 	void ClipAddSubsectorSegs(subsector_t*, TPlane* = NULL);
 };

--- a/source/p_entity.cpp
+++ b/source/p_entity.cpp
@@ -512,6 +512,10 @@ void VEntity::StartSound(VName Sound, vint32 Channel, float Volume,
 	float Attenuation, bool Loop)
 {
 	guard(VEntity::StartSound);
+	if (!Sector)
+	{
+		return;
+	}
 	if (Sector->SectorFlags & sector_t::SF_Silent)
 	{
 		return;

--- a/source/p_entity.h
+++ b/source/p_entity.h
@@ -156,6 +156,7 @@ class VEntity : public VThinker
 	VName			FixedSpriteName;
 	VStr			FixedModelName;
 	vuint8			ModelVersion;
+	int				NumTouchingLights;
 
 	vuint8			RenderStyle;
 	float			Alpha;
@@ -227,7 +228,7 @@ class VEntity : public VThinker
 		EF_Missile				= 0x01000000,	// don't hit same species, explode on block
 		EF_DontOverlap			= 0x02000000,	// Prevent some things from overlapping.
 		EF_UseDispState			= 0x04000000,	// Use DispState for rendering
-		EF_ActLikeBridge		= 0x08000000,	// Always allow obkects to pass.
+		EF_ActLikeBridge		= 0x08000000,	// Always allow objects to pass.
 		EF_NoDropOff			= 0x10000000,	// Can't drop off under any circumstances
 		EF_Bright				= 0x20000000,	// Always render full bright
 		EF_CanJump				= 0x40000000,	// This entity can jump to high places

--- a/source/p_entity_sight.cpp
+++ b/source/p_entity_sight.cpp
@@ -691,7 +691,7 @@ bool VEntity::CanSee(VEntity* Other)
 		return true;
 	}
 
-	//	Check feats
+	//	Check feet
 	Trace.End = Other->Origin;
 	Trace.End.z -= Other->FloorClip;
 #ifdef USE_BSP

--- a/source/p_gameobject.h
+++ b/source/p_gameobject.h
@@ -39,7 +39,10 @@ struct fakefloor_t;
 struct seg_t;
 struct subsector_t;
 struct node_t;
+struct surface_t;
+struct segpart_t;
 struct drawseg_t;
+struct sec_surface_t;
 struct subregion_t;
 
 class	VThinker;
@@ -76,6 +79,27 @@ enum
 // like some DOOM-alikes ("wt", "WebView") did.
 //
 typedef TVec vertex_t;
+
+//==========================================================================
+//
+//	DrawSeg
+//
+//==========================================================================
+
+struct drawseg_t
+{
+	seg_t*			seg;
+	drawseg_t*		next;
+
+	segpart_t*		top;
+	segpart_t*		mid;
+	segpart_t*		bot;
+	segpart_t*		topsky;
+	segpart_t*		extra;
+
+	surface_t*		HorizonTop;
+	surface_t*		HorizonBot;
+};
 
 //==========================================================================
 //
@@ -496,6 +520,24 @@ struct seg_t : public TPlane
 	int			side;
 
 	drawseg_t	*drawsegs;
+};
+
+//==========================================================================
+//
+//	SubRegion
+//
+//==========================================================================
+
+struct subregion_t
+{
+	sec_region_t*	secregion;
+	subregion_t*	next;
+	sec_plane_t*	floorplane;
+	sec_plane_t*	ceilplane;
+	sec_surface_t*	floor;
+	sec_surface_t*	ceil;
+	int				count;
+	drawseg_t*		lines;
 };
 
 //==========================================================================

--- a/source/p_level_think.cpp
+++ b/source/p_level_think.cpp
@@ -172,6 +172,7 @@ VThinker* VLevel::SpawnThinker(VClass* AClass, const TVec& AOrigin,
 	const TAVec& AAngles, mthing_t* mthing, bool AllowReplace)
 {
 	guard(VLevel::SpawnThinker);
+	check(AClass);
 	VClass* Class = AllowReplace ? AClass->GetReplacement() : AClass;
 	VThinker* Ret = (VThinker*)StaticSpawnObject(Class);
 	AddThinker(Ret);

--- a/source/p_world.cpp
+++ b/source/p_world.cpp
@@ -492,9 +492,9 @@ bool VPathTraverse::AddLineIntercepts(VThinker* Self, int mapx, int mapy,
 		num = ld->dist - DotProduct(trace_org, ld->normal);
 		frac = num / den;
 
-		if (frac < 0)
+		if (frac < 0 || frac > 1.0)
 		{
-			continue;	// behind source
+			continue;	// behind source or beyond end point
 		}
 
 		// try to early out the check

--- a/source/r_data.cpp
+++ b/source/r_data.cpp
@@ -441,7 +441,7 @@ void R_InstallSprite(const char *name, int index)
 
 	maxframe++;
 
-	for (int frame = 0 ; frame < maxframe ; frame++)
+	for (int frame = 0; frame < maxframe; frame++)
 	{
 		switch ((int)sprtemp[frame].rotate)
 		{
@@ -684,9 +684,9 @@ void VTextureTranslation::BuildPlayerTrans(int Start, int End, int Col)
 {
 	guard(VTextureTranslation::BuildPlayerTrans);
 	int Count = End - Start + 1;
-	vuint8 r = (Col >> 16) & 0xff;
-	vuint8 g = (Col >> 8) & 0xff;
-	vuint8 b = Col & 0xff;
+	vuint8 r = (Col >> 16) & 255;
+	vuint8 g = (Col >> 8) & 255;
+	vuint8 b = Col & 255;
 	vuint8 h, s, v;
 	M_RgbToHsv(r, g, b, h, s, v);
 	for (int i = 0; i < Count; i++)
@@ -847,9 +847,9 @@ void VTextureTranslation::MapToColours(int AStart, int AEnd, int AR1, int AG1,
 void VTextureTranslation::BuildBloodTrans(int Col)
 {
 	guard(VTextureTranslation::BuildBloodTrans);
-	vuint8 r = (Col >> 16) & 0xff;
-	vuint8 g = (Col >> 8) & 0xff;
-	vuint8 b = Col & 0xff;
+	vuint8 r = (Col >> 16) & 255;
+	vuint8 g = (Col >> 8) & 255;
+	vuint8 b = Col & 255;
 	//	Don't remap colour 0.
 	for (int i = 1; i < 256; i++)
 	{

--- a/source/r_light.cpp
+++ b/source/r_light.cpp
@@ -408,9 +408,9 @@ void VRenderLevel::SingleLightFace(light_t *light, surface_t *surf)
 	//
 	spt = surfpt;
 	squaredist = light->radius * light->radius;
-	rmul = ((light->colour >> 16) & 0xff) / 255.0;
-	gmul = ((light->colour >> 8) & 0xff) / 255.0;
-	bmul = (light->colour & 0xff) / 255.0;
+	rmul = ((light->colour >> 16) & 255) / 255.0;
+	gmul = ((light->colour >> 8) & 255) / 255.0;
+	bmul = (light->colour & 255) / 255.0;
 	for (c = 0; c < numsurfpt; c++, spt++)
 	{
 		dist = CastRay(light->origin, *spt, squaredist);
@@ -704,7 +704,7 @@ void VRenderLevelShared::DecayLights(float time)
 	dlight_t* dl = DLights;
 	for (int i = 0; i < MAX_DLIGHTS; i++, dl++)
 	{
-		if (dl->die < Level->Time || !dl->radius)
+		if (!dl->radius || dl->die < Level->Time)
 		{
 			continue;
 		}
@@ -802,7 +802,7 @@ void VRenderLevel::PushDlights()
 	dlight_t* l = DLights;
 	for (int i = 0; i < MAX_DLIGHTS; i++, l++)
 	{
-		if (l->die < Level->Time || !l->radius)
+		if (!l->radius || l->die < Level->Time)
 		{
 			continue;
 		}
@@ -929,9 +929,9 @@ vuint32 VRenderLevel::LightPoint(const TVec &p)
 			if (add > 0)
 			{
 				l += add;
-				lr += add * ((DLights[i].colour >> 16) & 0xff) / 255.0;
-				lg += add * ((DLights[i].colour >> 8) & 0xff) / 255.0;
-				lb += add * (DLights[i].colour & 0xff) / 255.0;
+				lr += add * ((DLights[i].colour >> 16) & 255) / 255.0;
+				lg += add * ((DLights[i].colour >> 8) & 255) / 255.0;
+				lb += add * (DLights[i].colour & 255) / 255.0;
 			}
 		}
 	}
@@ -975,7 +975,6 @@ void VRenderLevel::AddDynamicLights(surface_t *surf)
 	texinfo_t	*tex;
 	subsector_t *sub;
 	int			leafnum;
-
 
 	smax = (surf->extents[0] >> 4) + 1;
 	tmax = (surf->extents[1] >> 4) + 1;
@@ -1023,9 +1022,9 @@ void VRenderLevel::AddDynamicLights(surface_t *surf)
 			}
 		}
 
-		rmul = (DLights[lnum].colour >> 16) & 0xff;
-		gmul = (DLights[lnum].colour >> 8) & 0xff;
-		bmul = DLights[lnum].colour & 0xff;
+		rmul = (DLights[lnum].colour >> 16) & 255;
+		gmul = (DLights[lnum].colour >> 8) & 255;
+		bmul = DLights[lnum].colour & 255;
 
 		local.x = DotProduct(impact, tex->saxis) + tex->soffs;
 		local.y = DotProduct(impact, tex->taxis) + tex->toffs;

--- a/source/r_local.h
+++ b/source/r_local.h
@@ -89,21 +89,6 @@ struct segpart_t
 	float			RowOffset;
 };
 
-struct drawseg_t
-{
-	seg_t*			seg;
-	drawseg_t*		next;
-
-	segpart_t*		top;
-	segpart_t*		mid;
-	segpart_t*		bot;
-	segpart_t*		topsky;
-	segpart_t*		extra;
-
-	surface_t*		HorizonTop;
-	surface_t*		HorizonBot;
-};
-
 struct sec_surface_t
 {
 	sec_plane_t*	secplane;
@@ -113,18 +98,6 @@ struct sec_surface_t
 	float			YScale;
 	float			Angle;
 	surface_t*		surfs;
-};
-
-struct subregion_t
-{
-	sec_region_t*	secregion;
-	subregion_t*	next;
-	sec_plane_t*	floorplane;
-	sec_plane_t*	ceilplane;
-	sec_surface_t*	floor;
-	sec_surface_t*	ceil;
-	int				count;
-	drawseg_t*		lines;
 };
 
 struct fakefloor_t
@@ -346,7 +319,6 @@ protected:
 	sec_plane_t		sky_plane;
 	float			skyheight;
 	surface_t*		free_wsurfs;
-	vint32			MaxDrawSegs;
 	void*			AllocatedWSurfBlocks;
 	subregion_t*	AllocatedSubRegions;
 	drawseg_t*		AllocatedDrawSegs;
@@ -362,6 +334,8 @@ protected:
 	//	Moved here so that model rendering methods can be merged.
 	TVec			CurrLightPos;
 	float			CurrLightRadius;
+	int             CurrLightsNumber;
+	int             CurrShadowsNumber;
 
 	VRenderLevelShared(VLevel* ALevel);
 	~VRenderLevelShared();
@@ -556,28 +530,29 @@ private:
 
 	void BuildLightVis(int bspnum, float* bbox);
 	void DrawShadowSurfaces(surface_t* InSurfs, texinfo_t *texinfo,
-		bool CheckSkyBoxAlways);
+		bool CheckSkyBoxAlways, bool LightCanCross);
 	void RenderShadowLine(drawseg_t* dseg);
 	void RenderShadowSecSurface(sec_surface_t* ssurf, VEntity* SkyBox);
 	void RenderShadowSubRegion(subregion_t* region);
 	void RenderShadowSubsector(int num);
-	void RenderShadowBSPNode(int bspnum, float* bbox);
+	void RenderShadowBSPNode(int bspnum, float* bbox, bool LimitLights);
 	void DrawLightSurfaces(surface_t* InSurfs, texinfo_t *texinfo,
-		VEntity* SkyBox, bool CheckSkyBoxAlways);
+		VEntity* SkyBox, bool CheckSkyBoxAlways, bool LightCanCross);
 	void RenderLightLine(drawseg_t* dseg);
 	void RenderLightSecSurface(sec_surface_t* ssurf, VEntity* SkyBox);
 	void RenderLightSubRegion(subregion_t* region);
 	void RenderLightSubsector(int num);
-	void RenderLightBSPNode(int bspnum, float* bbox);
+	void RenderLightBSPNode(int bspnum, float* bbox, bool LimitLights);
 	void RenderLightShadows(const refdef_t* RD, const VViewClipper* Range,
-		TVec& Pos, float Radius, vuint32 Colour);
+		TVec& Pos, float Radius, vuint32 Colour, bool LimitLights);
 
 	//	Things
+	void ResetMobjsLightCount();
 	void RenderThingAmbient(VEntity*);
 	void RenderMobjsAmbient();
 	void RenderThingTextures(VEntity*);
 	void RenderMobjsTextures();
-	bool IsTouchedByLight(VEntity*);
+	bool IsTouchedByLight(VEntity*, bool);
 	void RenderThingLight(VEntity*);
 	void RenderMobjsLight();
 	void RenderThingShadow(VEntity*);

--- a/source/r_model.cpp
+++ b/source/r_model.cpp
@@ -58,6 +58,7 @@ struct VScriptSubModel
 	TArray<VName>		Skins;
 	bool				FullBright;
 	bool				NoShadow;
+	bool                UseDepth;
 };
 
 struct VScriptModel
@@ -343,6 +344,14 @@ static void ParseModelScript(VModel* Mdl, VStream& Strm)
 			if (SN->HasAttribute("noshadow"))
 			{
 				Md2.NoShadow = !SN->GetAttribute("noshadow").ICmp("true");
+			}
+
+			//	Force depth test flag.
+			//  For things like monsters with alpha transaparency
+			Md2.UseDepth = false;
+			if (SN->HasAttribute("usedepth"))
+			{
+				Md2.UseDepth = !SN->GetAttribute("usedepth").ICmp("true");
 			}
 
 			//	Process frames.
@@ -1034,10 +1043,10 @@ static void DrawModel(VLevel* Level, const TVec& Org, const TAVec& Angles,
 		switch (Pass)
 		{
 		case RPASS_Normal:
+		case RPASS_Light:
 			break;
 
 		case RPASS_ShadowVolumes:
-		case RPASS_Light:
 			if (Md2Alpha < 1.0 || SubMdl.NoShadow)
 			{
 				continue;
@@ -1116,7 +1125,7 @@ static void DrawModel(VLevel* Level, const TVec& Org, const TAVec& Angles,
 			Drawer->DrawAliasModel(Md2Org, Md2Angle, Offset, Scale,
 				SubMdl.Model, Md2Frame, Md2NextFrame, GTextureManager(SkinID),
 				Trans, ColourMap, Md2Light, Fade, Md2Alpha, Additive,
-				IsViewModel, smooth_inter, Interpolate);
+				IsViewModel, smooth_inter, Interpolate, SubMdl.UseDepth);
 			break;
 
 		case RPASS_Ambient:
@@ -1140,7 +1149,7 @@ static void DrawModel(VLevel* Level, const TVec& Org, const TAVec& Angles,
 		case RPASS_Textures:
 			Drawer->DrawAliasModelTextures(Md2Org, Md2Angle, Offset, Scale,
 				SubMdl.Model, Md2Frame, Md2NextFrame, GTextureManager(SkinID),
-				Trans, ColourMap, Md2Alpha, smooth_inter, Interpolate);
+				Trans, ColourMap, Md2Alpha, smooth_inter, Interpolate, SubMdl.UseDepth);
 			break;
 
 		case RPASS_Fog:

--- a/source/r_particle.cpp
+++ b/source/r_particle.cpp
@@ -185,7 +185,7 @@ void VRenderLevelShared::DrawParticles()
 		{
 			vuint32 Col = p->colour;
 			rgba_t TmpCol = ColourMaps[ColourMap].GetPalette()[R_LookupRGB(
-				(Col >> 16) & 0xff, (Col >> 8) & 0xff, Col & 0xff)];
+				(Col >> 16) & 255, (Col >> 8) & 255, Col & 255)];
 			p->colour = (Col & 0xff000000) | (TmpCol.r << 16) |
 				(TmpCol.g << 8) | TmpCol.b;
 			Drawer->DrawParticle(p);

--- a/source/r_public.h
+++ b/source/r_public.h
@@ -245,7 +245,7 @@ public:
 
 	static void AdjustGamma(rgba_t*, int);
 	static void SmoothEdges(vuint8*, int, int, vuint8*);
-	static void ResampleTexture(int, int, const vuint8*, int, int, vuint8*);
+	static void ResampleTexture(int, int, const vuint8*, int, int, vuint8*, int);
 	static void MipMap(int, int, vuint8*);
 
 protected:

--- a/source/r_sky.cpp
+++ b/source/r_sky.cpp
@@ -138,7 +138,7 @@ void R_InitSkyBoxes()
 static int CheckSkyboxNumForName(VName Name)
 {
 	guard(CheckSkyboxNumForName);
-	for (int num = skyboxinfo.Num() - 1; num >= 0 ; num--)
+	for (int num = skyboxinfo.Num() - 1; num >= 0; num--)
 	{
 		if (skyboxinfo[num].Name == Name)
 		{

--- a/source/snd_al.cpp
+++ b/source/snd_al.cpp
@@ -183,7 +183,11 @@ bool VOpenALDevice::Init()
 	//	Allocate array for buffers.
 	Buffers = new ALuint[GSoundManager->S_sfx.Num()];
 	memset(Buffers, 0, sizeof(ALuint) * GSoundManager->S_sfx.Num());
-	Sound3D = true;
+	if (GArgs.CheckParm("-3dsound"))
+	{
+		Sound3D = true;
+		GCon->Log(NAME_Init, "3D sound on");
+	}
 	return true;
 	unguard;
 }

--- a/source/snd_data.cpp
+++ b/source/snd_data.cpp
@@ -881,7 +881,7 @@ bool VSoundManager::IsSoundPresent(VName ClassName, VName GenderName,
 bool VSoundManager::LoadSound(int sound_id)
 {
 	guard(VSoundManager::LoadSound);
-	static const char* Exts[] = { "flac", "wav", "raw", NULL };
+	static const char* Exts[] = { "flac", "wav", "raw", "ogg", "mp3", NULL };
 
 	if (!S_sfx[sound_id].Data)
 	{

--- a/source/snd_gme.cpp
+++ b/source/snd_gme.cpp
@@ -196,7 +196,7 @@ bool VGMEAudioCodec::Finished()
 
 void VGMEAudioCodec::Restart()
 {
-	guard(VMikModAudioCodec::Restart);
+	guard(VGMEAudioCodec::Restart);
 	// If music is looping, restart playback by simply
 	// starting track 0 again and setting playing state
 	gme_start_track(emu, 0);

--- a/source/snd_win32.cpp
+++ b/source/snd_win32.cpp
@@ -180,7 +180,7 @@ bool VDirectSoundDevice::Init()
 	//  Set speaker type
 	if (snd_speaker_type > 5)
 	{
-		snd_mix_frequency = 5;
+		snd_speaker_type = 5;
 	}
 	DSound->SetSpeakerConfig(speaker_type[snd_speaker_type]);
 

--- a/source/sv_main.cpp
+++ b/source/sv_main.cpp
@@ -327,8 +327,12 @@ static void CheckForSkip()
 	if (skip)
 	{
 		for (i = 0; i < svs.max_clients; i++)
+		{
 			if (GGameInfo->Players[i])
+			{
 				GGameInfo->Players[i]->eventClientSkipIntermission();
+			}
+		}
 	}
 }
 
@@ -438,11 +442,11 @@ void SV_Ticker()
 	if (!real_time)
 	{
 		// Rounded a little bit up to prevent "slow motion"
-		host_frametime = 0.02857142857142857142857142857143f;//1.0 / 35.0;
+		host_frametime = 0.02857142857142857142857142857143f; //1.0 / 35.0;
 	}
 	else if (split_frame)
 	{
-		while (host_frametime / exec_times > 1.0 / 35.0)
+		while (host_frametime / exec_times > 0.02857142857142857142857142857143f) //1.0 / 35.0)
 		{
 			exec_times++;
 		}

--- a/source/sys_win.cpp
+++ b/source/sys_win.cpp
@@ -559,8 +559,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, PSTR, int iCmdShow)
 
 		//	Create window
 		hwnd = CreateWindowEx(WS_EX_APPWINDOW, "VAVOOM", "VAVOOM for Windows",
-			WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, 0, 0, 2, 2,
-			NULL, NULL, hInst, NULL);
+			(WS_OVERLAPPEDWINDOW & ~WS_MAXIMIZEBOX) | WS_CLIPCHILDREN |
+			 WS_CLIPSIBLINGS, 0, 0, 2, 2, NULL, NULL, hInst, NULL);
 		if (!hwnd)
 		{
 			MessageBox(NULL, "Couldn't create window", "Error", MB_OK);

--- a/source/ui_font.cpp
+++ b/source/ui_font.cpp
@@ -224,8 +224,14 @@ void VFont::StaticShutdown()
 	{
 		VFont* Next = F->Next;
 		delete F;
-		F = NULL;
-		F = Next;
+		if (Next)
+		{
+			F = Next;
+		}
+		else
+		{
+			F = NULL;
+		}
 	}
 	Fonts = NULL;
 	TextColours.Clear();
@@ -297,9 +303,9 @@ void VFont::ParseTextColours()
 				{
 					sc.ExpectString();
 					vuint32 C = M_ParseColour(sc.String);
-					Col.FlatColour.r = (C >> 16) & 0xff;
-					Col.FlatColour.g = (C >> 8) & 0xff;
-					Col.FlatColour.b = C & 0xff;
+					Col.FlatColour.r = (C >> 16) & 255;
+					Col.FlatColour.g = (C >> 8) & 255;
+					Col.FlatColour.b = C & 255;
 					Col.FlatColour.a = 255;
 				}
 				else
@@ -307,17 +313,17 @@ void VFont::ParseTextColours()
 					//	From colour.
 					sc.ExpectString();
 					vuint32 C = M_ParseColour(sc.String);
-					TDef.From.r = (C >> 16) & 0xff;
-					TDef.From.g = (C >> 8) & 0xff;
-					TDef.From.b = C & 0xff;
+					TDef.From.r = (C >> 16) & 255;
+					TDef.From.g = (C >> 8) & 255;
+					TDef.From.b = C & 255;
 					TDef.From.a = 255;
 
 					//	To colour.
 					sc.ExpectString();
 					C = M_ParseColour(sc.String);
-					TDef.To.r = (C >> 16) & 0xff;
-					TDef.To.g = (C >> 8) & 0xff;
-					TDef.To.b = C & 0xff;
+					TDef.To.r = (C >> 16) & 255;
+					TDef.To.g = (C >> 8) & 255;
+					TDef.To.b = C & 255;
 					TDef.To.a = 255;
 
 					if (sc.CheckNumber())
@@ -1403,7 +1409,10 @@ VFon1Font::VFon1Font(VName AName, int LumpNum)
 			// registered in texture manager.
 			GTextureManager.AddTexture(FChar.Textures[j]);
 		}
-		FChar.BaseTex = FChar.Textures[CR_UNTRANSLATED];
+		if (FChar.Textures[CR_UNTRANSLATED])
+		{
+			FChar.BaseTex = FChar.Textures[CR_UNTRANSLATED];
+		}
 
 		//	Skip character data.
 		int Count = SpaceWidth * FontHeight;
@@ -1558,7 +1567,10 @@ VFon2Font::VFon2Font(VName AName, int LumpNum)
 				// registered in texture manager.
 				GTextureManager.AddTexture(FChar.Textures[j]);
 			}
-			FChar.BaseTex = FChar.Textures[CR_UNTRANSLATED];
+			if (FChar.Textures[CR_UNTRANSLATED])
+			{
+				FChar.BaseTex = FChar.Textures[CR_UNTRANSLATED];
+			}
 
 			//	Skip character data.
 			do

--- a/source/vc_class.cpp
+++ b/source/vc_class.cpp
@@ -1934,6 +1934,7 @@ VClass* VClass::CreateDerivedClass(VName AName, VMemberBase* AOuter,
 VClass* VClass::GetReplacement()
 {
 	guard(VClass::GetReplacement);
+	check(this);
 	if (!Replacement)
 	{
 		return this;
@@ -1944,7 +1945,7 @@ VClass* VClass::GetReplacement()
 	VClass* Ret = Temp->GetReplacement();
 	Replacement = Temp;
 	return Ret;
-	unguard;
+	unguardf(("(%s)", ((VClass*)this)->GetName()));
 }
 
 //==========================================================================

--- a/source/vc_decorate.cpp
+++ b/source/vc_decorate.cpp
@@ -3034,9 +3034,9 @@ static void ParseActor(VScriptParser* sc, TArray<VClassFixup>& ClassFixups)
 							vuint32 Col;
 							sc->ExpectString();
 							Col = M_ParseColour(sc->String);
-							r = (Col >> 16) & 0xff;
-							g = (Col >> 8) & 0xff;
-							b = Col & 0xff;
+							r = (Col >> 16) & 255;
+							g = (Col >> 8) & 255;
+							b = Col & 255;
 						}
 						sc->Check(",");
 						sc->ExpectFloat();


### PR DESCRIPTION
    - Added multisampling_sample CVAR to allow the user to select a method to use for resizing textures in D3D and OpenGL.
    - Added a way to limit the amount of lights and shadows on models in advanced renderer by a CVAR (r_max_model_lights and r_max_model_shadows).
    - Added a way to limit the amount of lights and shadows on world geometry by a CVAR (r_max_lights and r_max_shadows).
    - Added a way to avoid rendering far away lights using a CVAR (r_lights_radius).
    - Added checks to clip geometry behind rendered BSP geometry to the clipper, this helps to improve performance.
    - Improved model rendering in different passes in the advanced renderer.
    - Other small fixes.