### PR TITLE
Sprite rendering changes

### DIFF
--- a/basev/common/glshaders/draw_shadow.fs
+++ b/basev/common/glshaders/draw_shadow.fs
@@ -8,5 +8,5 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	vec4 TexColour = texture2D(Texture, TextureCoordinate);
-	gl_FragColor = vec4(0.0, 0.0, 0.0, TexColour.a * Alpha);
+	gl_FragColor = vec4(0.0, 0.0, 0.0, smoothstep(0.1, 1.0, TexColour.a * Alpha));
 }

--- a/basev/common/glshaders/draw_simple.fs
+++ b/basev/common/glshaders/draw_simple.fs
@@ -8,10 +8,10 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate);
-	if (FinalColour.a < 0.666)
+	if (FinalColour.a < 0.4)
 	{
 		discard;
 	}
-	FinalColour.a *= Alpha;
+	FinalColour.a *= smoothstep(0.4, 1.0, Alpha);
 	gl_FragColor = FinalColour;
 }

--- a/basev/common/glshaders/shadows_ambient.fs
+++ b/basev/common/glshaders/shadows_ambient.fs
@@ -8,7 +8,7 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	vec4 TexColour = texture2D(Texture, TextureCoordinate);
-	if (TexColour.a <= 0.666)
+	if (TexColour.a <= 0.1)
 	{
 		discard;
 	}

--- a/basev/common/glshaders/shadows_fog.fs
+++ b/basev/common/glshaders/shadows_fog.fs
@@ -24,5 +24,5 @@ void main()
 		FogFactor = (FogEnd - z) / (FogEnd - FogStart);
 	}
 	FogFactor = clamp(1.0 - FogFactor, 0.0, 1.0);
-	gl_FragColor = vec4(FogColour.xyz, FogFactor);
+	gl_FragColor = vec4(FogColour.rgb, smoothstep(0.1, 1.0, FogFactor));
 }

--- a/basev/common/glshaders/shadows_light.fs
+++ b/basev/common/glshaders/shadows_light.fs
@@ -6,30 +6,51 @@ uniform float		LightRadius;
 varying vec3		Normal;
 varying float		Dist;
 varying vec3		VertToLight;
+varying vec3        VertToView;
+//varying vec3		VOrg;
 
 uniform sampler2D	Texture;
 varying vec2		TextureCoordinate;
 
 void main()
 {
+	float DistToView = length(VertToView);
+	if (DistToView <= 0.0)
+	{
+	    discard;
+	}
+	if (Dist <= 0.0)
+	{
+	    discard;
+	}
+
 	float DistToLight = length(VertToLight);
-	if (DistToLight >= LightRadius)
+	if (DistToLight <= 0.0)
 	{
 		discard;
 	}
+	if (DistToLight > LightRadius)
+	{
+		discard;
+	}
+
+	vec4 TexColour = texture2D(Texture, TextureCoordinate);
+	if (TexColour.a < 0.1)
+	{
+		discard;
+	}
+
 	vec3 Incoming = normalize(VertToLight);
 	float Angle = dot(Incoming, Normal);
 	Angle = 0.5 + 0.5 * Angle;
 	//float Add = LightRadius - Dist;
 	float Add = LightRadius - DistToLight;
 	Add *= Angle;
-	//if (Add <= 0.0)
-	//{
-	//	discard;
-	//}
+	if (Add <= 0.0)
+	{
+		discard;
+	}
 	Add = clamp(Add / 255.0, 0.0, 1.0);
 
-	vec4 TexColour = texture2D(Texture, TextureCoordinate);
-
-	gl_FragColor = vec4(LightColour.rgb, Add * TexColour.a);
+	gl_FragColor = vec4(LightColour.rgb, Add * smoothstep(0.1, 1.0, TexColour.a));
 }

--- a/basev/common/glshaders/shadows_light.vs
+++ b/basev/common/glshaders/shadows_light.vs
@@ -3,13 +3,6 @@
 uniform vec3		LightPos;
 uniform float		LightRadius;
 
-attribute vec3		SurfNormal;
-attribute float		SurfDist;
-
-varying vec3		Normal;
-varying float		Dist;
-varying vec3		VertToLight;
-
 uniform vec3		SAxis;
 uniform vec3		TAxis;
 uniform float		SOffs;
@@ -17,7 +10,17 @@ uniform float		TOffs;
 uniform float		TexIW;
 uniform float		TexIH;
 
+attribute vec3		SurfNormal;
+attribute float		SurfDist;
+attribute vec3		ViewOrigin;
+
+varying vec3		Normal;
+varying float		Dist;
+varying vec3		VertToLight;
+varying vec3        VertToView;
+
 varying vec2		TextureCoordinate;
+//varying vec3        VOrg;
 
 void main()
 {
@@ -29,7 +32,9 @@ void main()
 	float t = (dot(gl_Vertex.xyz, TAxis) + TOffs) * TexIH;
 	TextureCoordinate = vec2(s, t);
 
-	Normal = SurfNormal; 
+	Normal = SurfNormal;
 	Dist = dot(LightPos, SurfNormal) - SurfDist;
 	VertToLight.xyz = LightPos.xyz - gl_Vertex.xyz;
+    VertToView.xyz = ViewOrigin.xyz - gl_Vertex.xyz;
+//	VOrg = ViewOrigin;
 }

--- a/basev/common/glshaders/shadows_model_ambient.fs
+++ b/basev/common/glshaders/shadows_model_ambient.fs
@@ -10,10 +10,10 @@ uniform float		InAlpha;
 void main()
 {
 	vec4 TexColour = texture2D(Texture, TextureCoordinate);
-	if (TexColour.a <= 0.666)
+	if (TexColour.a < 0.1)
 	{
 		discard;
 	}
 
-	gl_FragColor = vec4(Light.rgb, InAlpha * TexColour.a);
+	gl_FragColor = vec4(Light.rgb, smoothstep(0.1, 1.0, InAlpha * TexColour.a));
 }

--- a/basev/common/glshaders/shadows_model_fog.fs
+++ b/basev/common/glshaders/shadows_model_fog.fs
@@ -14,7 +14,7 @@ uniform float		InAlpha;
 void main()
 {
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate);
-	if (FinalColour.a <= 0.333)
+	if (FinalColour.a <= 0.1)
 	{
 		discard;
 	}
@@ -35,5 +35,5 @@ void main()
 		FogFactor = ((FogEnd - z) / (FogEnd - FogStart));
 	}
 	FogFactor = clamp(1.0 - FogFactor, 0.0, 1.0) * InAlpha;
-	gl_FragColor = vec4(FogColour.rgb, FogFactor * FinalColour.a);
+	gl_FragColor = vec4(FogColour.rgb, smoothstep(0.1, 1.0, FogFactor * FinalColour.a));
 }

--- a/basev/common/glshaders/shadows_model_light.fs
+++ b/basev/common/glshaders/shadows_model_light.fs
@@ -12,7 +12,7 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	vec4 TexColour = texture2D(Texture, TextureCoordinate);
-	if (TexColour.a <= 0.666)
+	if (TexColour.a <= 0.1)
 	{
 		discard;
 	}
@@ -37,6 +37,6 @@ void main()
 		discard;
 	}
 
-	gl_FragColor = vec4(LightColour.r, LightColour.g, LightColour.b, Add * TexColour.a);
+	gl_FragColor = vec4(LightColour.r, LightColour.g, LightColour.b, smoothstep(0.1, 1.0, Add * TexColour.a));
 //	gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/basev/common/glshaders/shadows_model_textures.fs
+++ b/basev/common/glshaders/shadows_model_textures.fs
@@ -14,5 +14,5 @@ void main()
 		discard;
 	}
 
-	gl_FragColor = vec4(FinalColour.rgb, smoothstep(0.333, 1.0, InAlpha * FinalColour.a));
+	gl_FragColor = vec4(FinalColour.rgb, smoothstep(0.1, 1.0, InAlpha * FinalColour.a));
 }

--- a/basev/common/glshaders/shadows_model_textures.fs
+++ b/basev/common/glshaders/shadows_model_textures.fs
@@ -9,10 +9,10 @@ uniform float		InAlpha;
 void main()
 {
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate);
-	if (FinalColour.a <= 0.333)
+	if (FinalColour.a <= 0.1)
 	{
 		discard;
 	}
 
-	gl_FragColor = vec4(FinalColour.rgb, InAlpha * FinalColour.a);
+	gl_FragColor = vec4(FinalColour.rgb, smoothstep(0.333, 1.0, InAlpha * FinalColour.a));
 }

--- a/basev/common/glshaders/shadows_texture.fs
+++ b/basev/common/glshaders/shadows_texture.fs
@@ -6,5 +6,11 @@ varying vec2		TextureCoordinate;
 
 void main()
 {
-	gl_FragColor = texture2D(Texture, TextureCoordinate);
+	vec4 TexColour = texture2D(Texture, TextureCoordinate);
+	if (TexColour.a < 0.1)
+	{
+		discard;
+	}
+	TexColour.a *= smoothstep(0.1, 1.0, TexColour.a);
+	gl_FragColor = TexColour;
 }

--- a/basev/common/glshaders/surf_dsky.fs
+++ b/basev/common/glshaders/surf_dsky.fs
@@ -11,5 +11,5 @@ void main()
 {
 	vec4 Tex1 = texture2D(Texture, TextureCoordinate);
 	vec4 Tex2 = texture2D(Texture2, Texture2Coordinate);
-	gl_FragColor = mix(Tex1, Tex2, Tex2.a) * vec4(Brightness, Brightness, Brightness, 1.0);
+	gl_FragColor = mix(Tex1, Tex2, smoothstep(0.1, 1.0, Tex2.a)) * vec4(Brightness, Brightness, Brightness, 1.0);
 }

--- a/basev/common/glshaders/surf_lightmap.fs
+++ b/basev/common/glshaders/surf_lightmap.fs
@@ -18,6 +18,11 @@ void main()
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate) * texture2D(LightMap, LightmapCoordinate) +
 		 texture2D(SpecularMap, LightmapCoordinate);
 
+	if (FinalColour.a < 0.1)
+	{
+		discard;
+	}
+
 	if (FogEnabled)
 	{
 		float z = gl_FragCoord.z / gl_FragCoord.w;
@@ -36,7 +41,7 @@ void main()
 			FogFactor = (FogEnd - z) / (FogEnd - FogStart);
 		}
 		FogFactor = clamp(FogFactor, 0.0, 1.0);
-		FinalColour = mix(FogColour, FinalColour, FogFactor);
+		FinalColour = mix(FogColour, FinalColour, smoothstep(0.1, 1.0, FogFactor));
 	}
 
 	gl_FragColor = FinalColour;

--- a/basev/common/glshaders/surf_masked.fs
+++ b/basev/common/glshaders/surf_masked.fs
@@ -15,7 +15,7 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate) * Light;
-	if (FinalColour.a <= AlphaRef)
+	if (FinalColour.a < AlphaRef)
 	{
 		discard;
 	}
@@ -38,7 +38,7 @@ void main()
 			FogFactor = (FogEnd - z) / (FogEnd - FogStart);
 		}
 		FogFactor = clamp(FogFactor, 0.0, 1.0);
-		FinalColour = mix(FogColour, FinalColour, FogFactor);
+		FinalColour = mix(FogColour, FinalColour, smoothstep(AlphaRef, 1.0, FogFactor));
 	}
 
 	gl_FragColor = FinalColour;

--- a/basev/common/glshaders/surf_model.fs
+++ b/basev/common/glshaders/surf_model.fs
@@ -1,20 +1,20 @@
 #version 110
 
-uniform sampler2D	Texture;
-uniform bool		FogEnabled;
-uniform int			FogType;
-uniform vec4		FogColour;
-uniform float		FogDensity;
-uniform float		FogStart;
-uniform float		FogEnd;
+uniform sampler2D   Texture;
+uniform bool        FogEnabled;
+uniform int         FogType;
+uniform vec4        FogColour;
+uniform float       FogDensity;
+uniform float       FogStart;
+uniform float       FogEnd;
 
-varying vec4		Light;
-varying vec2		TextureCoordinate;
+varying vec4        Light;
+varying vec2        TextureCoordinate;
 
 void main()
 {
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate) * Light;
-	if (FinalColour.a <= 0.0)
+	if (FinalColour.a < 0.1)
 	{
 		discard;
 	}
@@ -37,7 +37,7 @@ void main()
 			FogFactor = (FogEnd - z) / (FogEnd - FogStart);
 		}
 		FogFactor = clamp(FogFactor, 0.0, 1.0);
-		FinalColour = mix(FogColour, FinalColour, FogFactor);
+		FinalColour = mix(FogColour, FinalColour, smoothstep(0.1, 1.0, FogFactor));
 	}
 
 	gl_FragColor = FinalColour;

--- a/basev/common/glshaders/surf_part.fs
+++ b/basev/common/glshaders/surf_part.fs
@@ -6,9 +6,9 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	float a = clamp((1.0 - length(TextureCoordinate)) * 2.0, 0.0, 1.0);
-	if (a <= 0.0)
+	if (a < 0.1)
 	{
 		discard;
 	}
-	gl_FragColor = Light * (1.0, 1.0, 1.0, a);
+	gl_FragColor = Light * (1.0, 1.0, 1.0, smoothstep(0.1, 1.0, a));
 }

--- a/basev/common/glshaders/surf_simple.fs
+++ b/basev/common/glshaders/surf_simple.fs
@@ -14,6 +14,10 @@ varying vec2		TextureCoordinate;
 void main()
 {
 	vec4 FinalColour = texture2D(Texture, TextureCoordinate) * Light;
+	if (FinalColour.a < 0.1)
+	{
+		discard;
+	}
 
 	if (FogEnabled)
 	{
@@ -33,7 +37,7 @@ void main()
 			FogFactor = (FogEnd - z) / (FogEnd - FogStart);
 		}
 		FogFactor = clamp(FogFactor, 0.0, 1.0);
-		FinalColour = mix(FogColour, FinalColour, FogFactor);
+		FinalColour = mix(FogColour, FinalColour, smoothstep(0.1, 1.0, FogFactor));
 	}
 
 	gl_FragColor = FinalColour;

--- a/source/d3d_main.cpp
+++ b/source/d3d_main.cpp
@@ -53,7 +53,7 @@ VCvarF VDirect3DDrawer::maxdist("d3d_maxdist", "8192.0", CVAR_Archive);
 VCvarI VDirect3DDrawer::model_lighting("d3d_model_lighting", "0", CVAR_Archive);
 VCvarI VDirect3DDrawer::specular_highlights("d3d_specular_highlights", "1", CVAR_Archive);
 VCvarI VDirect3DDrawer::avoid_input_lag("d3d_avoid_input_lag", "1", CVAR_Archive);
-VCvarI VDirect3DDrawer::multisampling_sample("d3d_multisampling_sample", "1", CVAR_Archive);
+VCvarI VDirect3DDrawer::multisampling_sample("d3d_multisampling_sample", "2", CVAR_Archive);
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 

--- a/source/d3d_poly.cpp
+++ b/source/d3d_poly.cpp
@@ -560,6 +560,10 @@ void VDirect3DDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 
 	texinfo_t* tex = surf->texinfo;
 	SetTexture(tex->Tex, tex->ColourMap);
+	
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_POINT);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_POINT);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, D3DTEXF_NONE);
 
 	if (surf->lightmap != NULL ||
 		surf->dlightframe == r_dlightframecount)
@@ -624,6 +628,10 @@ void VDirect3DDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 	{
 		RenderDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
 	}
+
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, magfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, minfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, mipfilter);
 	unguard;
 }
 

--- a/source/d3d_poly.cpp
+++ b/source/d3d_poly.cpp
@@ -609,7 +609,7 @@ void VDirect3DDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 	if (blend_sprites || Additive || Alpha < 1.0)
 	{
 		RenderDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE);
-		RenderDevice->SetRenderState(D3DRS_ALPHAREF, 28);
+		RenderDevice->SetRenderState(D3DRS_ALPHAREF, 85);
 	}
 	if (Additive)
 	{
@@ -651,6 +651,10 @@ void VDirect3DDrawer::DrawSpritePolygon(TVec *cv, VTexture* Tex, float Alpha,
 
 	SetSpriteLump(Tex, Translation, CMap);
 
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, D3DTEXF_LINEAR);
+
 	int l = ((int)(Alpha * 255) << 24) | (light & 0x00ffffff);
 	for (int i = 0; i < 4; i++)
 	{
@@ -684,6 +688,10 @@ void VDirect3DDrawer::DrawSpritePolygon(TVec *cv, VTexture* Tex, float Alpha,
 		RenderDevice->SetRenderState(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
 	}
 	RenderDevice->SetRenderState(D3DRS_ALPHATESTENABLE, FALSE);
+
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, magfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, minfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, mipfilter);
 	unguard;
 }
 

--- a/source/d3d_tex.cpp
+++ b/source/d3d_tex.cpp
@@ -171,6 +171,10 @@ void VDirect3DDrawer::PrecacheTexture(VTexture* Tex)
 void VDirect3DDrawer::SetTexture(VTexture* Tex, int CMap)
 {
 	guard(VDirect3DDrawer::SetTexture);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, magfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, minfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, mipfilter);
+
 	SetSpriteLump(Tex, NULL, CMap);
 	if (RenderDevice)
 	{
@@ -239,6 +243,10 @@ void VDirect3DDrawer::SetPic(VTexture* Tex, VTextureTranslation* Trans,
 	int CMap)
 {
 	guard(VDirect3DDrawer::SetPic);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, magfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, minfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, mipfilter);
+
 	SetSpriteLump(Tex, Trans, CMap);
 	unguard;
 }
@@ -380,6 +388,10 @@ LPDIRECT3DTEXTURE9 VDirect3DDrawer::UploadTexture(int width, int height, const r
 	vuint8					*stackbuf = (vuint8 *)Z_Malloc(256 * 128 * 4);
 	LPDIRECT3DTEXTURE9		surf;
 	UINT					level;
+
+	RenderDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, magfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MINFILTER, minfilter);
+	RenderDevice->SetSamplerState(0, D3DSAMP_MIPFILTER, mipfilter);
 
 	w = ToPowerOf2(width);
 	if (w > maxTexSize)

--- a/source/gl_main.cpp
+++ b/source/gl_main.cpp
@@ -56,7 +56,7 @@ VCvarI VOpenGLDrawer::ext_vertex_buffer_objects("gl_ext_vertex_buffer_objects", 
 VCvarF VOpenGLDrawer::maxdist("gl_maxdist", "8192.0", CVAR_Archive);
 VCvarI VOpenGLDrawer::model_lighting("gl_model_lighting", "0", CVAR_Archive);
 VCvarI VOpenGLDrawer::specular_highlights("gl_specular_highlights", "1", CVAR_Archive);
-VCvarI VOpenGLDrawer::multisampling_sample("gl_multisampling_sample", "1", CVAR_Archive);
+VCvarI VOpenGLDrawer::multisampling_sample("gl_multisampling_sample", "2", CVAR_Archive);
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 

--- a/source/gl_poly.cpp
+++ b/source/gl_poly.cpp
@@ -1181,6 +1181,7 @@ void VOpenGLDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 
 	texinfo_t* tex = surf->texinfo;
 	SetTexture(tex->Tex, tex->ColourMap);
+
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
@@ -1235,7 +1236,7 @@ void VOpenGLDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 
 		if (blend_sprites || Additive || Alpha < 1.0)
 		{
-			p_glUniform1fARB(SurfMaskedAlphaRefLoc, 0.111);
+			p_glUniform1fARB(SurfMaskedAlphaRefLoc, 0.333);
 			glEnable(GL_BLEND);
 		}
 		else
@@ -1329,7 +1330,6 @@ void VOpenGLDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 	}
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
-
 	unguard;
 }
 
@@ -1348,6 +1348,9 @@ void VOpenGLDrawer::DrawSpritePolygon(TVec *cv, VTexture* Tex, float Alpha,
 	TVec	texpt;
 
 	SetSpriteLump(Tex, Translation, CMap);
+
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_LINEAR);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 	if (HaveShaders)
 	{
@@ -1478,6 +1481,8 @@ void VOpenGLDrawer::DrawSpritePolygon(TVec *cv, VTexture* Tex, float Alpha,
 		}
 		glDisable(GL_ALPHA_TEST);
 	}
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
 	unguard;
 }
 

--- a/source/gl_poly.cpp
+++ b/source/gl_poly.cpp
@@ -294,8 +294,8 @@ void VOpenGLDrawer::WorldDrawing()
 			}
 
 			glBindTexture(GL_TEXTURE_2D, addmap_id[lb]);
-			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minfilter);
-			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 			if (RendLev->add_changed[lb])
 			{
@@ -1181,6 +1181,8 @@ void VOpenGLDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 
 	texinfo_t* tex = surf->texinfo;
 	SetTexture(tex->Tex, tex->ColourMap);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 	if (HaveShaders)
 	{
@@ -1325,6 +1327,9 @@ void VOpenGLDrawer::DrawMaskedPolygon(surface_t* surf, float Alpha,
 		}
 		glDisable(GL_ALPHA_TEST);
 	}
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
+
 	unguard;
 }
 
@@ -1508,7 +1513,7 @@ void VOpenGLDrawer::StartParticles()
 		{
 			glBindTexture(GL_TEXTURE_2D, particle_texture);
 			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
-			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minfilter);
+			glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
 			glBegin(GL_QUADS);
 		}
 	}

--- a/source/gl_tex.cpp
+++ b/source/gl_tex.cpp
@@ -412,6 +412,9 @@ void VOpenGLDrawer::UploadTexture(int width, int height, const rgba_t* data)
 			GL_UNSIGNED_BYTE, image);
 	}
 
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
+
 	if (image != stackbuf)
 	{
 		Z_Free(image);

--- a/source/gl_tex.cpp
+++ b/source/gl_tex.cpp
@@ -185,6 +185,9 @@ void VOpenGLDrawer::PrecacheTexture(VTexture* Tex)
 void VOpenGLDrawer::SetTexture(VTexture* Tex, int CMap)
 {
 	guard(VOpenGLDrawer::SetTexture);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
+
 	SetSpriteLump(Tex, NULL, CMap);
 	unguard;
 }
@@ -231,8 +234,6 @@ void VOpenGLDrawer::SetSpriteLump(VTexture* Tex,
 		}
 	}
 
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
 	tex_iw = 1.0 / Tex->GetWidth();
 	tex_ih = 1.0 / Tex->GetHeight();
 	unguard;
@@ -248,6 +249,9 @@ void VOpenGLDrawer::SetPic(VTexture* Tex, VTextureTranslation* Trans,
 	int CMap)
 {
 	guard(VOpenGLDrawer::SetPic);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
+
 	SetSpriteLump(Tex, Trans, CMap);
 	unguard;
 }
@@ -368,6 +372,9 @@ void VOpenGLDrawer::UploadTexture(int width, int height, const rgba_t* data)
 	int		level;
 	vuint8*	stackbuf = (vuint8 *)Z_Malloc(256 * 128 * 4);
 
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
+
 	w = ToPowerOf2(width);
 	if (w > maxTexSize)
 	{
@@ -411,9 +418,6 @@ void VOpenGLDrawer::UploadTexture(int width, int height, const rgba_t* data)
 		glTexImage2D(GL_TEXTURE_2D, level, 4, w, h, 0, GL_RGBA,
 			GL_UNSIGNED_BYTE, image);
 	}
-
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipfilter);
-	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, maxfilter);
 
 	if (image != stackbuf)
 	{

--- a/source/r_tex_base.cpp
+++ b/source/r_tex_base.cpp
@@ -432,7 +432,7 @@ void VTexture::SmoothEdges(vuint8* buffer, int w, int h, vuint8* dataout)
 	}
 	l1 += 4;
 
-	for(x = 1; x < w - 1; x++, l1 += 4)
+	for (x = 1; x < w - 1; x++, l1 += 4)
 	{
 		if (l1[MSB] == 0 && !CHKPIX(-1) && !CHKPIX(1))
 		{
@@ -445,7 +445,7 @@ void VTexture::SmoothEdges(vuint8* buffer, int w, int h, vuint8* dataout)
 	}
 	l1 += 4;
 
-	for(y = 1; y < h - 1; y++)
+	for (y = 1; y < h - 1; y++)
 	{
 		if (l1[MSB] == 0 && !CHKPIX(-w) && !CHKPIX(1))
 		{
@@ -453,9 +453,9 @@ void VTexture::SmoothEdges(vuint8* buffer, int w, int h, vuint8* dataout)
 		}
 		l1 += 4;
 
-		for(x = 1; x < w - 1; x++, l1 += 4)
+		for (x = 1; x < w - 1; x++, l1 += 4)
 		{
-			if (l1[MSB] == 0 && !CHKPIX(-w) && !CHKPIX(-1) && !CHKPIX(1))
+			if (l1[MSB] == 0 && !CHKPIX(-w) && !CHKPIX(-1) && !CHKPIX(1) && !CHKPIX(-w - 1) && !CHKPIX(-w + 1) && !CHKPIX(w - 1) && !CHKPIX(w + 1))
 			{
 				CHKPIX(w);
 			}
@@ -472,7 +472,7 @@ void VTexture::SmoothEdges(vuint8* buffer, int w, int h, vuint8* dataout)
 		CHKPIX(1);
 	}
 	l1 += 4;
-	for(x = 1;x < w - 1; x++, l1 += 4)
+	for (x = 1; x < w - 1; x++, l1 += 4)
 	{
 		if (l1[MSB] == 0 && !CHKPIX(-w) && !CHKPIX(-1))
 		{
@@ -557,13 +557,19 @@ void VTexture::ResampleTexture(int widthin, int heightin,
 			{
 				i0 = int(i * sy);
 				i1 = i0 + 1;
-				if (i1 >= heightin) i1 = heightin - 1;
+				if (i1 >= heightin)
+				{
+					i1 = heightin - 1;
+				}
 				alpha = i * sy - i0;
 				for (j = 0; j < widthout; j++)
 				{
 					j0 = int(j * sx);
 					j1 = j0 + 1;
-					if (j1 >= widthin) j1 = widthin - 1;
+					if (j1 >= widthin)
+					{
+						j1 = widthin - 1;
+					}
 					beta = j * sx - j0;
 
 					/* compute weighted average of pixels in rect (i0,j0)-(i1,j1) */
@@ -596,12 +602,18 @@ void VTexture::ResampleTexture(int widthin, int heightin,
 			{
 				i0 = int(i * sy);
 				i1 = i0 + 1;
-				if (i1 >= heightin) i1 = heightin - 1;
+				if (i1 >= heightin)
+				{
+					i1 = heightin - 1;
+				}
 				for (j = 0; j < widthout; j++)
 				{
 					j0 = int(j * sx);
 					j1 = j0 + 1;
-					if (j1 >= widthin) j1 = widthin - 1;
+					if (j1 >= widthin)
+					{
+						j1 = widthin - 1;
+					}
 
 					dst = dataout + (i * widthout + j) * 4;
 


### PR DESCRIPTION
- Fixed drawing of transparencies in shaders for models, world surfaces and UI sprites.
- Fixed drawing of masked surfaces in D3D and OpenGL regular and advanced renderers.
- Changed default value of multisampling_sample to 2, since it looks much better.
- Improved checks for SmoothEdges method, so it works better with semitransparent pixels.
- Changed filtering combination used for sprite rendering again, to look more like in version 1.33.